### PR TITLE
fix post carousel date

### DIFF
--- a/modules/PostCarousel/Item.php
+++ b/modules/PostCarousel/Item.php
@@ -156,7 +156,7 @@ class Item {
 			$format = get_option( 'date_format' );
 		}
 
-		return date_i18n( $format, $this->get_post()->post_modified );
+		return date_i18n( $format, strtotime( $this->get_post()->post_modified ) );
 	}
 
 	/**


### PR DESCRIPTION
this change fixes the problem with the post carousel date - fixes #27

This change was also suggested by [Mauricio Galetto](https://wordpress.org/support/users/tauri77/) via [wordpress.org](https://wordpress.org/support/topic/current-date-in-all-post-carousel-items/)